### PR TITLE
Update to version 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+<a name="1.1.2"></a>
+## [1.1.2](https://github.com/hexenq/kuroshiro/compare/1.1.1...1.1.2) (2018-10-19)
+
+### Bug Fixes
+
+* fix conversion bug when handling chōon with passport-shiki romanization ([#47](https://github.com/hexenq/kuroshiro/issues/47))
+* fix kanji->romaji conversion bug when using nippon-shiki/hepburn-shiki romanization ([#46](https://github.com/hexenq/kuroshiro/issues/46))
+
+### Test
+
+* Update test specification
+
+### Miscellaneous
+
+* Update docs, add notice for romaji conversion
+
 <a name="1.1.1"></a>
 ## [1.1.1](https://github.com/hexenq/kuroshiro/compare/1.1.0...1.1.1) (2018-08-28)
 

--- a/README.jp.md
+++ b/README.jp.md
@@ -220,6 +220,15 @@ kuroshiroは三種類のローマ字表記法をサポートします。
 
 各種ローマ字表の比較は[こちら](http://jgrammar.life.coocan.jp/ja/data/rohmaji2.htm)を参考にしてください。
 
+### ローマ字変換のお知らせ
+フリガナは音声を正確にあらわしていないため、__フリガナ__ を __ローマ字__ に完全自動的に変換することは不可能です。（[なぜフリガナではダメなのか？](https://green.adam.ne.jp/roomazi/onamae.html#naze)を参照）
+
+そのゆえ、`nippon`、`hepburn`のローマ字表記法を使って、フリガナ（仮名）-> ローマ字 変換を行うとき、kuroshiroは長音の処理を実行しません。（`passport`表記法そのものが長音を無視します）
+
+*例えば`nippon`、` passport`、 `hepburn`のローマ字表記法を使って フリガナ->ローマ字 変換を行うと、それぞれ"kousi"、 "koshi"、 "koushi"が得られます。*
+
+フリガナモードを使うかどうかにかかわらず、漢字->ローマ字の変換はこの仕組みに影響を与えられないです。
+
 ## 貢献したい方
 [CONTRIBUTING](CONTRIBUTING.md) を参考にしてみてください。
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Convert given string to target syllabary with options available
 __Arguments__
 
 * `str` - A String to be converted.
-* `options` - *Optional* kuroshiro has several convert options as below. `romajiSystem` is only applied when the value of param `to` is `romaji`
+* `options` - *Optional* kuroshiro has several convert options as below.
 
 | Options | Type | Default | Description |
 |---|---|---|---|
@@ -207,7 +207,7 @@ Convert input kana string to hiragana.
 Convert input kana string to katakana.
 
 #### kanaToRomaji(str, system)
-Convert input kana string to romaji. Param `system` accepts `"nippon"`, `"passport"`, `"hepburn"` (Default: "hepburn")
+Convert input kana string to romaji. Param `system` accepts `"nippon"`, `"passport"`, `"hepburn"` (Default: "hepburn"). 
 
 ## Romanization System
 kuroshiro supports three kinds of romanization systems.
@@ -219,6 +219,16 @@ kuroshiro supports three kinds of romanization systems.
 `hepburn`: Hepburn romanization. Refer to [BS 4812 : 1972](https://archive.is/PiJ4).
 
 There is a useful [webpage](http://jgrammar.life.coocan.jp/ja/data/rohmaji2.htm) for you to check the difference between these romanization systems.
+
+### Notice for Romaji Conversion
+Since it's impossible to fully automatically convert __furigana__ directly to __romaji__ because furigana lacks information on pronunciation (Refer to [なぜ フリガナでは ダメなのか？](https://green.adam.ne.jp/roomazi/onamae.html#naze)). 
+
+kuroshiro will not handle chōon when processing directly furigana (kana) -> romaji conversion with `nippon` or `hepburn` romanization system (Chōon will be ignored by `passport` romanization system) 
+
+*For example, you'll get "kousi", "koshi", "koushi" respectively when converts kana "こうし" to romaji 
+using `nippon`, `passport`, `hepburn` romanization system.*
+
+The kanji -> romaji conversion with/without furigana mode is __unaffected__ by this logic.
 
 ## Contributing
 Please check [CONTRIBUTING](CONTRIBUTING.md).

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -208,7 +208,7 @@ const result = Kuroshiro.Util.isHiragana("あ"));
 转换输入假名字符串至片假名。
 
 #### kanaToRomaji(str, system)
-转换输入假名字符串至罗马字。参数`system`可选值为`"nippon"`, `"passport"`, `"hepburn"` (默认值: "hepburn")
+转换输入假名字符串至罗马字。参数`system`可选值为`"nippon"`, `"passport"`, `"hepburn"` (默认值: "hepburn")。
 
 ## 罗马字体系
 kuroshiro支持三种罗马字体系。
@@ -220,6 +220,15 @@ kuroshiro支持三种罗马字体系。
 `hepburn`: 平文罗马字。参照 [BS 4812 : 1972](https://archive.is/PiJ4)。
 
 想快速了解这些罗马字体系的不同，可参考这个实用的[网页](http://jgrammar.life.coocan.jp/ja/data/rohmaji2.htm)。
+
+### 罗马字转换须知
+完全自动化进行注音假名到罗马字的直接转换是不可能的，这是因为一般的注音假名都缺乏正确的发音信息，可以参考 [なぜ フリガナでは ダメなのか？](https://green.adam.ne.jp/roomazi/onamae.html#naze)。
+
+因此kuroshiro在进行直接的注音假名->罗马字转换（使用`nippon`或`hepburn`罗马字体系）时，不会处理长音。(`passport`罗马字体系本身便忽略长音)
+
+*例如，当进行假名"こうし"到罗马字的转换时，对于`nippon`, `passport`, `hepburn`三种罗马字体系，你会分别得到"kousi", "koshi", "koushi"这几个结果*
+
+汉字->罗马字的转换无论使用注音假名模式与否都 __不受__ 此逻辑影响。
 
 ## 贡献
 请查阅文档 [CONTRIBUTING](CONTRIBUTING.md).

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -208,7 +208,7 @@ const result = Kuroshiro.Util.isHiragana("あ"));
 轉換輸入假名字元串至片假名。
 
 #### kanaToRomaji(str, system)
-轉換輸入假名字元串至羅馬字。參數`system`可選值為`"nippon"`, `"passport"`, `"hepburn"` (默認值: "hepburn")
+轉換輸入假名字元串至羅馬字。參數`system`可選值為`"nippon"`, `"passport"`, `"hepburn"` (默認值: "hepburn")。
 
 ## 羅馬字體系
 kuroshiro支持三種羅馬字體系。
@@ -220,6 +220,15 @@ kuroshiro支持三種羅馬字體系。
 `hepburn`: 平文羅馬字。參照 [BS 4812 : 1972](https://archive.is/PiJ4)。
 
 想快速了解這些羅馬字體系的不同，可參考這個實用的[網頁](http://jgrammar.life.coocan.jp/ja/data/rohmaji2.htm)。
+
+### 羅馬字轉換須知
+完全自動化進行注音假名到羅馬字的直接轉換是不可能的，這是因為一般的注音假名都缺乏正確的發音信息，可以參考 [なぜ フリガナでは ダメなのか？](https://green.adam.ne.jp/roomazi/onamae.html#naze)。
+
+因此kuroshiro在進行直接的注音假名->羅馬字轉換（使用`nippon`或`hepburn`羅馬字體系）時，不會處理長音。(`passport`羅馬字體系本身便忽略長音)
+
+*例如，當進行假名"こうし"到羅馬字的轉換時，對於`nippon`, `passport`, `hepburn`三種羅馬字體系，你會分別得到"kousi", "koshi", "koushi"這幾個結果*
+
+漢字->羅馬字的轉換無論使用注音假名模式與否都 __不受__ 此邏輯影響。
 
 ## 貢獻
 請查閱文檔 [CONTRIBUTING](CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuroshiro",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "kuroshiro is a Japanese language library for converting Japanese sentence to Hiragana, Katakana or Romaji with furigana and okurigana modes supported.",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/core.js
+++ b/src/core.js
@@ -102,10 +102,20 @@ class Kuroshiro {
                     }
                     return tokens.map(token => token.reading).join(" ");
                 case "romaji":
+                    const romajiConv = (token) => {
+                        let preToken;
+                        if (hasJapanese(token.surface_form)) {
+                            preToken = token.pronunciation || token.reading;
+                        }
+                        else {
+                            preToken = token.surface_form;
+                        }
+                        return toRawRomaji(preToken, options.romajiSystem);
+                    };
                     if (options.mode === "normal") {
-                        return tokens.map(token => toRawRomaji(token.pronunciation || token.reading, options.romajiSystem)).join("");
+                        return tokens.map(romajiConv).join("");
                     }
-                    return tokens.map(token => toRawRomaji(token.pronunciation || token.reading, options.romajiSystem)).join(" ");
+                    return tokens.map(romajiConv).join(" ");
                 case "hiragana":
                     for (let hi = 0; hi < tokens.length; hi++) {
                         if (hasKanji(tokens[hi].surface_form)) {

--- a/src/core.js
+++ b/src/core.js
@@ -93,24 +93,6 @@ class Kuroshiro {
 
         const rawTokens = await this._analyzer.parse(str);
         const tokens = patchTokens(rawTokens);
-        for (let cr = 0; cr < tokens.length; cr++) {
-            if (hasJapanese(tokens[cr].surface_form)) {
-                if (!tokens[cr].reading) {
-                    if (tokens[cr].surface_form.split().every(isKana)) {
-                        tokens[cr].reading = toRawKatakana(tokens[cr].surface_form);
-                    }
-                    else {
-                        tokens[cr].reading = tokens[cr].surface_form;
-                    }
-                }
-                else if (hasHiragana(tokens[cr].reading)) {
-                    tokens[cr].reading = toRawKatakana(tokens[cr].reading);
-                }
-            }
-            else {
-                tokens[cr].reading = tokens[cr].surface_form;
-            }
-        }
 
         if (options.mode === "normal" || options.mode === "spaced") {
             switch (options.to) {

--- a/src/util.js
+++ b/src/util.js
@@ -1474,6 +1474,26 @@ const getStrType = function (str) {
  * @return {Object} Patched tokens
  */
 const patchTokens = function (tokens) {
+    // patch for token structure
+    for (let cr = 0; cr < tokens.length; cr++) {
+        if (hasJapanese(tokens[cr].surface_form)) {
+            if (!tokens[cr].reading) {
+                if (tokens[cr].surface_form.split("").every(isKana)) {
+                    tokens[cr].reading = toRawKatakana(tokens[cr].surface_form);
+                }
+                else {
+                    tokens[cr].reading = tokens[cr].surface_form;
+                }
+            }
+            else if (hasHiragana(tokens[cr].reading)) {
+                tokens[cr].reading = toRawKatakana(tokens[cr].reading);
+            }
+        }
+        else {
+            tokens[cr].reading = tokens[cr].surface_form;
+        }
+    }
+
     // patch for 助動詞"う" after 動詞
     for (let i = 0; i < tokens.length; i++) {
         if (tokens[i].pos && tokens[i].pos === "助動詞" && (tokens[i].surface_form === "う" || tokens[i].surface_form === "ウ")) {

--- a/test/node.spec.js
+++ b/test/node.spec.js
@@ -4,6 +4,7 @@
 
 import KuromojiAnalyzer from "kuroshiro-analyzer-kuromoji";
 import Kuroshiro from "../src";
+import { patchTokens } from "../src/util";
 
 describe("Kuroshiro Node Initialization Test", () => {
     let kuroshiro;
@@ -94,6 +95,11 @@ describe("Kuroshiro Node Funtional Test", () => {
             done();
         }
     });
+    it("Token Patch", () => {
+        const tokens = JSON.parse("[{\"surface_form\":\"綺麗\",\"pos\":\"名詞\",\"reading\":\"きれい\"},{\"surface_form\":\"な\",\"pos\":\"助動詞\"},{\"surface_form\":\"花\",\"pos\":\"名詞\",\"reading\":\"ハナ\"},{\"surface_form\":\"。\",\"pos\":\"記号\",\"reading\":\"。\"},{\"surface_form\":\"面白い\",\"pos\":\"形容詞\",\"reading\":\"オモシロイ\"},{\"surface_form\":\"映画\",\"pos\":\"名詞\",\"reading\":\"エイガ\"},{\"surface_form\":\"。\",\"pos\":\"記号\",\"reading\":\"。\"},{\"surface_form\":\"面白かっ\",\"pos\":\"形容詞\",\"reading\":\"オモシロカッ\"},{\"surface_form\":\"た\",\"pos\":\"助動詞\",\"reading\":\"タ\"},{\"surface_form\":\"です\",\"pos\":\"助動詞\",\"reading\":\"デス\"},{\"surface_form\":\"。\",\"pos\":\"記号\",\"reading\":\"。\"},{\"surface_form\":\"繋ご\",\"pos\":\"動詞\",\"reading\":\"ツナゴ\"},{\"surface_form\":\"う\",\"pos\":\"助動詞\",\"reading\":\"ウ\"},{\"surface_form\":\"うp\",\"pos\":\"名詞\"}]");
+        const result = patchTokens(tokens);
+        expect(result).toHaveLength(12);
+    });
     it("Kana Character Recognition", () => {
         const ori = "こ";
         const result = Kuroshiro.Util.isKana(ori);
@@ -104,10 +110,15 @@ describe("Kuroshiro Node Funtional Test", () => {
         const result = Kuroshiro.Util.isKanji(ori);
         expect(result).toBeTruthy();
     });
-    it("Kana-mixed String Recognition", () => {
+    it("Kana-mixed String Recognition(T)", () => {
         const ori = "この公園の中で";
         const result = Kuroshiro.Util.hasKana(ori);
         expect(result).toBeTruthy();
+    });
+    it("Kana-mixed String Recognition(F)", () => {
+        const ori = "abc漢字";
+        const result = Kuroshiro.Util.hasKana(ori);
+        expect(result).toBeFalsy();
     });
     it("Kanji-mixed String Recognition", () => {
         const ori = "この公園の中で";

--- a/test/node.spec.js
+++ b/test/node.spec.js
@@ -182,27 +182,47 @@ describe("Kuroshiro Node Funtional Test", () => {
     it("Kanji to Romaji", async () => {
         const ori = EXAMPLE_TEXT;
         const result = await kuroshiro.convert(ori, { to: "romaji" });
-        expect(result).toEqual("kanjitoretarateotsunagou,kasanarunohajinseinorain and remiriasaikou!");
+        expect(result).toEqual("kanjitoretarateotsunagō,kasanarunowajinseinorain and remiriasaikō!");
     });
-    it("Kanji to Romaji with passport-shiki romaji system", async () => {
-        const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { to: "romaji", romajiSystem: "passport" });
-        expect(result).toEqual("kanjitoretarateotsunagou,kasanarunohajinseinorain and remiriasaiko!");
-    });
-    it("Kanji to Hiragana with spaces", async () => {
-        const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { mode: "spaced", to: "hiragana" });
-        expect(result).toEqual("かんじとれ たら て を つなご う 、 かさなる の は じんせい の ライン   and   レミ リア さいこう ！");
-    });
-    it("Kanji to Katakana with spaces", async () => {
-        const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { mode: "spaced", to: "katakana" });
-        expect(result).toEqual("カンジトレ タラ テ ヲ ツナゴ ウ 、 カサナル ノ ハ ジンセイ ノ ライン   and   レミ リア サイコウ ！");
+    it("Kanji to Romaji with sokuon", async () => {
+        const ori = "勝手に買っちゃったんだ";
+        const result = await kuroshiro.convert(ori, { mode: "spaced", to: "romaji" });
+        expect(result).toEqual("katte ni katchatta n da");
     });
     it("Kanji to Romaji with spaces", async () => {
         const ori = EXAMPLE_TEXT;
         const result = await kuroshiro.convert(ori, { mode: "spaced", to: "romaji" });
-        expect(result).toEqual("kanjitore tara te o tsunago u , kasanaru no ha jinsei no rain   and   remi ria saikou !");
+        expect(result).toEqual("kanjitore tara te o tsunagō , kasanaru no wa jinsei no rain   and   remi ria saikō !");
+    });
+    it("Kanji to Romaji with passport-shiki romaji system", async () => {
+        const ori = EXAMPLE_TEXT;
+        const result = await kuroshiro.convert(ori, { to: "romaji", romajiSystem: "passport" });
+        expect(result).toEqual("kanjitoretarateotsunago,kasanarunowajinseinorain and remiriasaiko!");
+    });
+    it("Kanji to Romaji misc with hepburn-shiki romaji system", async () => {
+        const ori = "東京、九州、丸の内、観桜、呼応、思う、長雨、記入、金融、学校、ビール、お母さん、委員";
+        const result = await kuroshiro.convert(ori, { to: "romaji" });
+        expect(result).toEqual("tōkyō,kyūshū,marunouchi,kan'ō,koō,omou,nagaame,kinyū,kin'yū,gakkō,bīru,okāsan,iin");
+    });
+    it("Kanji to Romaji misc with nippon-shiki romaji system", async () => {
+        const ori = "東京、九州、丸の内、観桜、呼応、思う、長雨、記入、金融、学校、ビール、お母さん、委員";
+        const result = await kuroshiro.convert(ori, { to: "romaji", romajiSystem: "nippon" });
+        expect(result).toEqual("tôkyô,kyûsyû,marunouti,kan'ô,koô,omou,nagaame,kinyû,kin'yû,gakkô,bîru,okâsan,iin");
+    });
+    it("Kanji to Romaji misc with passport-shiki romaji system", async () => {
+        const ori = "東京、九州、丸の内、観桜、呼応、思う、長雨、記入、金融、学校、ビール、お母さん、委員";
+        const result = await kuroshiro.convert(ori, { to: "romaji", romajiSystem: "passport" });
+        expect(result).toEqual("tokyo,kyushu,marunouchi,kano,koo,omou,nagaame,kinyu,kinyu,gakko,biru,okasan,iin");
+    });
+    it("Kanji to Hiragana with spaces", async () => {
+        const ori = EXAMPLE_TEXT;
+        const result = await kuroshiro.convert(ori, { mode: "spaced", to: "hiragana" });
+        expect(result).toEqual("かんじとれ たら て を つなごう 、 かさなる の は じんせい の ライン   and   レミ リア さいこう ！");
+    });
+    it("Kanji to Katakana with spaces", async () => {
+        const ori = EXAMPLE_TEXT;
+        const result = await kuroshiro.convert(ori, { mode: "spaced", to: "katakana" });
+        expect(result).toEqual("カンジトレ タラ テ ヲ ツナゴウ 、 カサナル ノ ハ ジンセイ ノ ライン   and   レミ リア サイコウ ！");
     });
     it("Kanji to Hiragana with okurigana(1)", async () => {
         const ori = EXAMPLE_TEXT;
@@ -242,7 +262,7 @@ describe("Kuroshiro Node Funtional Test", () => {
     it("Kanji to Romaji with okurigana", async () => {
         const ori = EXAMPLE_TEXT;
         const result = await kuroshiro.convert(ori, { mode: "okurigana", to: "romaji" });
-        expect(result).toEqual("感(kan)じ取(to)れたら手(te)を繋(tsuna)ごう、重(kasa)なるのは人生(jinsei)のライン and レミリア最高(saikou)！");
+        expect(result).toEqual("感(kan)じ取(to)れたら手(te)を繋(tsuna)ごう、重(kasa)なるのは人生(jinsei)のライン and レミリア最高(saikō)！");
     });
     it("Kanji to Hiragana with furigana", async () => {
         const ori = EXAMPLE_TEXT;
@@ -257,6 +277,6 @@ describe("Kuroshiro Node Funtional Test", () => {
     it("Kanji to Romaji with furigana", async () => {
         const ori = EXAMPLE_TEXT;
         const result = await kuroshiro.convert(ori, { mode: "furigana", to: "romaji" });
-        expect(result).toEqual("<ruby>感<rp>(</rp><rt>kan</rt><rp>)</rp>じ<rp>(</rp><rt>ji</rt><rp>)</rp>取<rp>(</rp><rt>to</rt><rp>)</rp>れ<rp>(</rp><rt>re</rt><rp>)</rp>た<rp>(</rp><rt>ta</rt><rp>)</rp>ら<rp>(</rp><rt>ra</rt><rp>)</rp>手<rp>(</rp><rt>te</rt><rp>)</rp>を<rp>(</rp><rt>o</rt><rp>)</rp>繋<rp>(</rp><rt>tsuna</rt><rp>)</rp>ご<rp>(</rp><rt>go</rt><rp>)</rp>う<rp>(</rp><rt>u</rt><rp>)</rp>、<rp>(</rp><rt>,</rt><rp>)</rp>重<rp>(</rp><rt>kasa</rt><rp>)</rp>な<rp>(</rp><rt>na</rt><rp>)</rp>る<rp>(</rp><rt>ru</rt><rp>)</rp>の<rp>(</rp><rt>no</rt><rp>)</rp>は<rp>(</rp><rt>ha</rt><rp>)</rp>人生<rp>(</rp><rt>jinsei</rt><rp>)</rp>の<rp>(</rp><rt>no</rt><rp>)</rp>ラ<rp>(</rp><rt>ra</rt><rp>)</rp>イ<rp>(</rp><rt>i</rt><rp>)</rp>ン<rp>(</rp><rt>n</rt><rp>)</rp> <rp>(</rp><rt> </rt><rp>)</rp>a<rp>(</rp><rt>a</rt><rp>)</rp>n<rp>(</rp><rt>n</rt><rp>)</rp>d<rp>(</rp><rt>d</rt><rp>)</rp> <rp>(</rp><rt> </rt><rp>)</rp>レ<rp>(</rp><rt>re</rt><rp>)</rp>ミ<rp>(</rp><rt>mi</rt><rp>)</rp>リ<rp>(</rp><rt>ri</rt><rp>)</rp>ア<rp>(</rp><rt>a</rt><rp>)</rp>最高<rp>(</rp><rt>saikou</rt><rp>)</rp>！<rp>(</rp><rt>!</rt><rp>)</rp></ruby>");
+        expect(result).toEqual("<ruby>感<rp>(</rp><rt>kan</rt><rp>)</rp>じ<rp>(</rp><rt>ji</rt><rp>)</rp>取<rp>(</rp><rt>to</rt><rp>)</rp>れ<rp>(</rp><rt>re</rt><rp>)</rp>た<rp>(</rp><rt>ta</rt><rp>)</rp>ら<rp>(</rp><rt>ra</rt><rp>)</rp>手<rp>(</rp><rt>te</rt><rp>)</rp>を<rp>(</rp><rt>o</rt><rp>)</rp>繋<rp>(</rp><rt>tsuna</rt><rp>)</rp>ご<rp>(</rp><rt>go</rt><rp>)</rp>う<rp>(</rp><rt>u</rt><rp>)</rp>、<rp>(</rp><rt>,</rt><rp>)</rp>重<rp>(</rp><rt>kasa</rt><rp>)</rp>な<rp>(</rp><rt>na</rt><rp>)</rp>る<rp>(</rp><rt>ru</rt><rp>)</rp>の<rp>(</rp><rt>no</rt><rp>)</rp>は<rp>(</rp><rt>wa</rt><rp>)</rp>人生<rp>(</rp><rt>jinsei</rt><rp>)</rp>の<rp>(</rp><rt>no</rt><rp>)</rp>ラ<rp>(</rp><rt>ra</rt><rp>)</rp>イ<rp>(</rp><rt>i</rt><rp>)</rp>ン<rp>(</rp><rt>n</rt><rp>)</rp> <rp>(</rp><rt> </rt><rp>)</rp>a<rp>(</rp><rt>a</rt><rp>)</rp>n<rp>(</rp><rt>n</rt><rp>)</rp>d<rp>(</rp><rt>d</rt><rp>)</rp> <rp>(</rp><rt> </rt><rp>)</rp>レ<rp>(</rp><rt>re</rt><rp>)</rp>ミ<rp>(</rp><rt>mi</rt><rp>)</rp>リ<rp>(</rp><rt>ri</rt><rp>)</rp>ア<rp>(</rp><rt>a</rt><rp>)</rp>最高<rp>(</rp><rt>saikō</rt><rp>)</rp>！<rp>(</rp><rt>!</rt><rp>)</rp></ruby>");
     });
 });


### PR DESCRIPTION
### Bug Fixes

* fix conversion bug when handling chōon with passport-shiki romanization ([#47](https://github.com/hexenq/kuroshiro/issues/47))
* fix kanji->romaji conversion bug when using nippon-shiki/hepburn-shiki romanization ([#46](https://github.com/hexenq/kuroshiro/issues/46))

### Test

* Update test specification

### Miscellaneous

* Update docs, add notice for romaji conversion