### PR TITLE
Change to sync

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -69,7 +69,7 @@ class Kuroshiro {
      * @param {string} [options.delimiter_end=")"] Delimiter(End)
      * @returns {string} Result of conversion
      */
-    convert(str, options) {
+    convertSync(str, options) {
         options = options || {};
         options.to = options.to || "hiragana";
         options.mode = options.mode || "normal";
@@ -91,7 +91,7 @@ class Kuroshiro {
             throw new Error("Invalid Romanization System.");
         }
 
-        const rawTokens = this._analyzer.parse(str);
+        const rawTokens = this._analyzer.parseSync(str);
         const tokens = patchTokens(rawTokens);
 
         if (options.mode === "normal" || options.mode === "spaced") {
@@ -294,6 +294,23 @@ class Kuroshiro {
                     throw new Error("Invalid Target Syllabary.");
             }
         }
+    }
+
+    /**
+     * Asynchronously convert given string to target syllabary with options available
+     * @memberOf Kuroshiro
+     * @instance
+     * @param {string} str Given String
+     * @param {Object} [options] Settings Object
+     * @param {string} [options.to="hiragana"] Target syllabary ["hiragana"|"katakana"|"romaji"]
+     * @param {string} [options.mode="normal"] Convert mode ["normal"|"spaced"|"okurigana"|"furigana"]
+     * @param {string} [options.romajiSystem="hepburn"] Romanization System ["nippon"|"passport"|"hepburn"]
+     * @param {string} [options.delimiter_start="("] Delimiter(Start)
+     * @param {string} [options.delimiter_end=")"] Delimiter(End)
+     * @returns {Promise<string>} Promise result of conversion
+     */
+    convert(str, options) {
+        return Promise.resolve(this.convertSync(str, options));
     }
 }
 

--- a/src/core.js
+++ b/src/core.js
@@ -67,9 +67,9 @@ class Kuroshiro {
      * @param {string} [options.romajiSystem="hepburn"] Romanization System ["nippon"|"passport"|"hepburn"]
      * @param {string} [options.delimiter_start="("] Delimiter(Start)
      * @param {string} [options.delimiter_end=")"] Delimiter(End)
-     * @returns {Promise} Promise object represents the result of conversion
+     * @returns {string} Result of conversion
      */
-    async convert(str, options) {
+    convert(str, options) {
         options = options || {};
         options.to = options.to || "hiragana";
         options.mode = options.mode || "normal";
@@ -91,7 +91,7 @@ class Kuroshiro {
             throw new Error("Invalid Romanization System.");
         }
 
-        const rawTokens = await this._analyzer.parse(str);
+        const rawTokens = this._analyzer.parse(str);
         const tokens = patchTokens(rawTokens);
 
         if (options.mode === "normal" || options.mode === "spaced") {

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -21,7 +21,7 @@ describe("Kuroshiro Browser Test", () => {
     });
     it("Convert Test", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { to: "hiragana" });
         expect(result).toEqual("かんじとれたらてをつなごう、かさなるのはじんせいのライン and レミリアさいこう！");
     });
 });

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -19,9 +19,9 @@ describe("Kuroshiro Browser Test", () => {
         const result = Kuroshiro.Util.isKanji(ori);
         expect(result).toBeTruthy();
     });
-    it("Convert Test", async () => {
+    it("Convert Test", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { to: "hiragana" });
+        const result = kuroshiro.convert(ori, { to: "hiragana" });
         expect(result).toEqual("かんじとれたらてをつなごう、かさなるのはじんせいのライン and レミリアさいこう！");
     });
 });

--- a/test/node.spec.js
+++ b/test/node.spec.js
@@ -9,7 +9,7 @@ import { patchTokens } from "../src/util";
 describe("Kuroshiro Node Initialization Test", () => {
     let kuroshiro;
 
-    beforeAll(async () => {
+    beforeAll(() => {
         kuroshiro = new Kuroshiro();
     });
     it("Invalid Initialization Parameter(1)", async (done) => {
@@ -65,35 +65,23 @@ describe("Kuroshiro Node Funtional Test", () => {
         kuroshiro = new Kuroshiro();
         await kuroshiro.init(new KuromojiAnalyzer());
     });
-    it("Convert - Wrong Parameter - Invalid Target Syllabary", async (done) => {
+    it("Convert - Wrong Parameter - Invalid Target Syllabary", () => {
         const ori = EXAMPLE_TEXT;
-        try {
-            const result = await kuroshiro.convert(ori, { to: "xxxx" });
-            done("SHOULD NOT BE HERE");
-        }
-        catch (err) {
-            done();
-        }
+        expect(() => {
+            kuroshiro.convert(ori, { to: "xxxx" });
+        }).toThrowError();
     });
-    it("Convert - Wrong Parameter - Invalid Conversion Mode", async (done) => {
+    it("Convert - Wrong Parameter - Invalid Conversion Mode", () => {
         const ori = EXAMPLE_TEXT;
-        try {
-            const result = await kuroshiro.convert(ori, { to: "hiragana", mode: "xxxx" });
-            done("SHOULD NOT BE HERE");
-        }
-        catch (err) {
-            done();
-        }
+        expect(() => {
+            kuroshiro.convert(ori, { to: "hiragana", mode: "xxxx" });
+        }).toThrowError();
     });
-    it("Convert - Wrong Parameter - Invalid Romanization System", async (done) => {
+    it("Convert - Wrong Parameter - Invalid Romanization System", () => {
         const ori = EXAMPLE_TEXT;
-        try {
-            const result = await kuroshiro.convert(ori, { to: "hiragana", romajiSystem: "xxxx" });
-            done("SHOULD NOT BE HERE");
-        }
-        catch (err) {
-            done();
-        }
+        expect(() => {
+            kuroshiro.convert(ori, { to: "hiragana", romajiSystem: "xxxx" });
+        }).toThrowError();
     });
     it("Token Patch", () => {
         const tokens = JSON.parse("[{\"surface_form\":\"綺麗\",\"pos\":\"名詞\",\"reading\":\"きれい\"},{\"surface_form\":\"な\",\"pos\":\"助動詞\"},{\"surface_form\":\"花\",\"pos\":\"名詞\",\"reading\":\"ハナ\"},{\"surface_form\":\"。\",\"pos\":\"記号\",\"reading\":\"。\"},{\"surface_form\":\"面白い\",\"pos\":\"形容詞\",\"reading\":\"オモシロイ\"},{\"surface_form\":\"映画\",\"pos\":\"名詞\",\"reading\":\"エイガ\"},{\"surface_form\":\"。\",\"pos\":\"記号\",\"reading\":\"。\"},{\"surface_form\":\"面白かっ\",\"pos\":\"形容詞\",\"reading\":\"オモシロカッ\"},{\"surface_form\":\"た\",\"pos\":\"助動詞\",\"reading\":\"タ\"},{\"surface_form\":\"です\",\"pos\":\"助動詞\",\"reading\":\"デス\"},{\"surface_form\":\"。\",\"pos\":\"記号\",\"reading\":\"。\"},{\"surface_form\":\"繋ご\",\"pos\":\"動詞\",\"reading\":\"ツナゴ\"},{\"surface_form\":\"う\",\"pos\":\"助動詞\",\"reading\":\"ウ\"},{\"surface_form\":\"うp\",\"pos\":\"名詞\"}]");
@@ -165,129 +153,129 @@ describe("Kuroshiro Node Funtional Test", () => {
         const result = Kuroshiro.Util.kanaToRomaji(ori, "hepburn");
         expect(result).toEqual("matcha");
     });
-    it("Kanji to Hiragana(1)", async () => {
+    it("Kanji to Hiragana(1)", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { to: "hiragana" });
+        const result = kuroshiro.convert(ori, { to: "hiragana" });
         expect(result).toEqual("かんじとれたらてをつなごう、かさなるのはじんせいのライン and レミリアさいこう！");
     });
-    it("Kanji to Hiragana(2)", async () => {
+    it("Kanji to Hiragana(2)", () => {
         const ori = EXAMPLE_TEXT2;
-        const result = await kuroshiro.convert(ori, { to: "hiragana" });
+        const result = kuroshiro.convert(ori, { to: "hiragana" });
         expect(result).toEqual("ブラウンかんへのあいがたりねぇな");
     });
-    it("Kanji to Hiragana(3)", async () => {
+    it("Kanji to Hiragana(3)", () => {
         const ori = EXAMPLE_TEXT3;
-        const result = await kuroshiro.convert(ori, { to: "hiragana" });
+        const result = kuroshiro.convert(ori, { to: "hiragana" });
         expect(result).toEqual("せきがはらのたたかい");
     });
-    it("Kanji to Katakana", async () => {
+    it("Kanji to Katakana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { to: "katakana" });
+        const result = kuroshiro.convert(ori, { to: "katakana" });
         expect(result).toEqual("カンジトレタラテヲツナゴウ、カサナルノハジンセイノライン and レミリアサイコウ！");
     });
-    it("Kanji to Katakana (Simple One Chara)", async () => {
+    it("Kanji to Katakana (Simple One Chara)", () => {
         const ori = "あ い う え お か き く け こ さ し す せ そ た ち つ て と な に ぬ ね の は ひ ふ へ ほ ま み む め も や ゆ よ ら り る れ ろ わ を ん が ぎ ぐ げ ご ざ じ ず ぜ ぞ だ ぢ づ で ど ば び ぶ べ ぼ ぱ ぴ ぷ ぺ ぽ きゃ きゅ きょ しゃ しゅ しょ ちゃ ちゅ ちょ にゃ にゅ にょ ひゃ ひゅ ひょ みゃ みゅ みょ りゃ りゅ りょ ぎゃ ぎゅ ぎょ じゃ じゅ じょ びゃ びゅ びょ ぴゃ ぴゅ ぴょ";
-        const result = await kuroshiro.convert(ori, { to: "katakana" });
+        const result = kuroshiro.convert(ori, { to: "katakana" });
         expect(result).toEqual("ア イ ウ エ オ カ キ ク ケ コ サ シ ス セ ソ タ チ ツ テ ト ナ ニ ヌ ネ ノ ハ ヒ フ ヘ ホ マ ミ ム メ モ ヤ ユ ヨ ラ リ ル レ ロ ワ ヲ ン ガ ギ グ ゲ ゴ ザ ジ ズ ゼ ゾ ダ ヂ ヅ デ ド バ ビ ブ ベ ボ パ ピ プ ペ ポ キャ キュ キョ シャ シュ ショ チャ チュ チョ ニャ ニュ ニョ ヒャ ヒュ ヒョ ミャ ミュ ミョ リャ リュ リョ ギャ ギュ ギョ ジャ ジュ ジョ ビャ ビュ ビョ ピャ ピュ ピョ");
     });
-    it("Kanji to Romaji", async () => {
+    it("Kanji to Romaji", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { to: "romaji" });
+        const result = kuroshiro.convert(ori, { to: "romaji" });
         expect(result).toEqual("kanjitoretarateotsunagō,kasanarunowajinseinorain and remiriasaikō!");
     });
-    it("Kanji to Romaji with sokuon", async () => {
+    it("Kanji to Romaji with sokuon", () => {
         const ori = "勝手に買っちゃったんだ";
-        const result = await kuroshiro.convert(ori, { mode: "spaced", to: "romaji" });
+        const result = kuroshiro.convert(ori, { mode: "spaced", to: "romaji" });
         expect(result).toEqual("katte ni katchatta n da");
     });
-    it("Kanji to Romaji with spaces", async () => {
+    it("Kanji to Romaji with spaces", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { mode: "spaced", to: "romaji" });
+        const result = kuroshiro.convert(ori, { mode: "spaced", to: "romaji" });
         expect(result).toEqual("kanjitore tara te o tsunagō , kasanaru no wa jinsei no rain   and   remi ria saikō !");
     });
-    it("Kanji to Romaji with passport-shiki romaji system", async () => {
+    it("Kanji to Romaji with passport-shiki romaji system", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { to: "romaji", romajiSystem: "passport" });
+        const result = kuroshiro.convert(ori, { to: "romaji", romajiSystem: "passport" });
         expect(result).toEqual("kanjitoretarateotsunago,kasanarunowajinseinorain and remiriasaiko!");
     });
-    it("Kanji to Romaji misc with hepburn-shiki romaji system", async () => {
+    it("Kanji to Romaji misc with hepburn-shiki romaji system", () => {
         const ori = "東京、九州、丸の内、観桜、呼応、思う、長雨、記入、金融、学校、ビール、お母さん、委員";
-        const result = await kuroshiro.convert(ori, { to: "romaji" });
+        const result = kuroshiro.convert(ori, { to: "romaji" });
         expect(result).toEqual("tōkyō,kyūshū,marunouchi,kan'ō,koō,omou,nagaame,kinyū,kin'yū,gakkō,bīru,okāsan,iin");
     });
-    it("Kanji to Romaji misc with nippon-shiki romaji system", async () => {
+    it("Kanji to Romaji misc with nippon-shiki romaji system", () => {
         const ori = "東京、九州、丸の内、観桜、呼応、思う、長雨、記入、金融、学校、ビール、お母さん、委員";
-        const result = await kuroshiro.convert(ori, { to: "romaji", romajiSystem: "nippon" });
+        const result = kuroshiro.convert(ori, { to: "romaji", romajiSystem: "nippon" });
         expect(result).toEqual("tôkyô,kyûsyû,marunouti,kan'ô,koô,omou,nagaame,kinyû,kin'yû,gakkô,bîru,okâsan,iin");
     });
-    it("Kanji to Romaji misc with passport-shiki romaji system", async () => {
+    it("Kanji to Romaji misc with passport-shiki romaji system", () => {
         const ori = "東京、九州、丸の内、観桜、呼応、思う、長雨、記入、金融、学校、ビール、お母さん、委員";
-        const result = await kuroshiro.convert(ori, { to: "romaji", romajiSystem: "passport" });
+        const result = kuroshiro.convert(ori, { to: "romaji", romajiSystem: "passport" });
         expect(result).toEqual("tokyo,kyushu,marunouchi,kano,koo,omou,nagaame,kinyu,kinyu,gakko,biru,okasan,iin");
     });
-    it("Kanji to Hiragana with spaces", async () => {
+    it("Kanji to Hiragana with spaces", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { mode: "spaced", to: "hiragana" });
+        const result = kuroshiro.convert(ori, { mode: "spaced", to: "hiragana" });
         expect(result).toEqual("かんじとれ たら て を つなごう 、 かさなる の は じんせい の ライン   and   レミ リア さいこう ！");
     });
-    it("Kanji to Katakana with spaces", async () => {
+    it("Kanji to Katakana with spaces", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { mode: "spaced", to: "katakana" });
+        const result = kuroshiro.convert(ori, { mode: "spaced", to: "katakana" });
         expect(result).toEqual("カンジトレ タラ テ ヲ ツナゴウ 、 カサナル ノ ハ ジンセイ ノ ライン   and   レミ リア サイコウ ！");
     });
-    it("Kanji to Hiragana with okurigana(1)", async () => {
+    it("Kanji to Hiragana with okurigana(1)", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("感(かん)じ取(と)れたら手(て)を繋(つな)ごう、重(かさ)なるのは人生(じんせい)のライン and レミリア最高(さいこう)！");
     });
-    it("Kanji to Hiragana with okurigana(2)", async () => {
+    it("Kanji to Hiragana with okurigana(2)", () => {
         const ori = EXAMPLE_TEXT2;
-        const result = await kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("ブラウン管(かん)への愛(あい)が足(た)りねぇな");
     });
-    it("Kanji to Hiragana with okurigana(3)", async () => {
+    it("Kanji to Hiragana with okurigana(3)", () => {
         const ori = EXAMPLE_TEXT3;
-        const result = await kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("関ヶ原(せきがはら)の戦(たたか)い");
     });
-    it("Kanji to Hiragana with okurigana(4)", async () => {
+    it("Kanji to Hiragana with okurigana(4)", () => {
         const ori = EXAMPLE_TEXT4;
-        const result = await kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("綺麗(きれい)な花(はな)。面白(おもしろ)い映画(えいが)。面白(おもしろ)かったです。");
     });
-    it("Kanji to Hiragana with okurigana(5)", async () => {
+    it("Kanji to Hiragana with okurigana(5)", () => {
         const ori = EXAMPLE_TEXT5;
-        const result = await kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("言(い)い訳(わけ)");
     });
-    it("Kanji to Hiragana with okurigana(6)", async () => {
+    it("Kanji to Hiragana with okurigana(6)", () => {
         const ori = EXAMPLE_TEXT6;
-        const result = await kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("可愛(かわい)い");
     });
-    it("Kanji to Katakana with okurigana", async () => {
+    it("Kanji to Katakana with okurigana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { mode: "okurigana", to: "katakana" });
+        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "katakana" });
         expect(result).toEqual("感(カン)じ取(ト)れたら手(テ)を繋(ツナ)ごう、重(カサ)なるのは人生(ジンセイ)のライン and レミリア最高(サイコウ)！");
     });
-    it("Kanji to Romaji with okurigana", async () => {
+    it("Kanji to Romaji with okurigana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { mode: "okurigana", to: "romaji" });
+        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "romaji" });
         expect(result).toEqual("感(kan)じ取(to)れたら手(te)を繋(tsuna)ごう、重(kasa)なるのは人生(jinsei)のライン and レミリア最高(saikō)！");
     });
-    it("Kanji to Hiragana with furigana", async () => {
+    it("Kanji to Hiragana with furigana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { mode: "furigana", to: "hiragana" });
+        const result = kuroshiro.convert(ori, { mode: "furigana", to: "hiragana" });
         expect(result).toEqual("<ruby>感<rp>(</rp><rt>かん</rt><rp>)</rp></ruby>じ<ruby>取<rp>(</rp><rt>と</rt><rp>)</rp></ruby>れたら<ruby>手<rp>(</rp><rt>て</rt><rp>)</rp></ruby>を<ruby>繋<rp>(</rp><rt>つな</rt><rp>)</rp></ruby>ごう、<ruby>重<rp>(</rp><rt>かさ</rt><rp>)</rp></ruby>なるのは<ruby>人生<rp>(</rp><rt>じんせい</rt><rp>)</rp></ruby>のライン and レミリア<ruby>最高<rp>(</rp><rt>さいこう</rt><rp>)</rp></ruby>！");
     });
-    it("Kanji to Katakana with furigana", async () => {
+    it("Kanji to Katakana with furigana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { mode: "furigana", to: "katakana" });
+        const result = kuroshiro.convert(ori, { mode: "furigana", to: "katakana" });
         expect(result).toEqual("<ruby>感<rp>(</rp><rt>カン</rt><rp>)</rp></ruby>じ<ruby>取<rp>(</rp><rt>ト</rt><rp>)</rp></ruby>れたら<ruby>手<rp>(</rp><rt>テ</rt><rp>)</rp></ruby>を<ruby>繋<rp>(</rp><rt>ツナ</rt><rp>)</rp></ruby>ごう、<ruby>重<rp>(</rp><rt>カサ</rt><rp>)</rp></ruby>なるのは<ruby>人生<rp>(</rp><rt>ジンセイ</rt><rp>)</rp></ruby>のライン and レミリア<ruby>最高<rp>(</rp><rt>サイコウ</rt><rp>)</rp></ruby>！");
     });
-    it("Kanji to Romaji with furigana", async () => {
+    it("Kanji to Romaji with furigana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = await kuroshiro.convert(ori, { mode: "furigana", to: "romaji" });
+        const result = kuroshiro.convert(ori, { mode: "furigana", to: "romaji" });
         expect(result).toEqual("<ruby>感<rp>(</rp><rt>kan</rt><rp>)</rp>じ<rp>(</rp><rt>ji</rt><rp>)</rp>取<rp>(</rp><rt>to</rt><rp>)</rp>れ<rp>(</rp><rt>re</rt><rp>)</rp>た<rp>(</rp><rt>ta</rt><rp>)</rp>ら<rp>(</rp><rt>ra</rt><rp>)</rp>手<rp>(</rp><rt>te</rt><rp>)</rp>を<rp>(</rp><rt>o</rt><rp>)</rp>繋<rp>(</rp><rt>tsuna</rt><rp>)</rp>ご<rp>(</rp><rt>go</rt><rp>)</rp>う<rp>(</rp><rt>u</rt><rp>)</rp>、<rp>(</rp><rt>,</rt><rp>)</rp>重<rp>(</rp><rt>kasa</rt><rp>)</rp>な<rp>(</rp><rt>na</rt><rp>)</rp>る<rp>(</rp><rt>ru</rt><rp>)</rp>の<rp>(</rp><rt>no</rt><rp>)</rp>は<rp>(</rp><rt>wa</rt><rp>)</rp>人生<rp>(</rp><rt>jinsei</rt><rp>)</rp>の<rp>(</rp><rt>no</rt><rp>)</rp>ラ<rp>(</rp><rt>ra</rt><rp>)</rp>イ<rp>(</rp><rt>i</rt><rp>)</rp>ン<rp>(</rp><rt>n</rt><rp>)</rp> <rp>(</rp><rt> </rt><rp>)</rp>a<rp>(</rp><rt>a</rt><rp>)</rp>n<rp>(</rp><rt>n</rt><rp>)</rp>d<rp>(</rp><rt>d</rt><rp>)</rp> <rp>(</rp><rt> </rt><rp>)</rp>レ<rp>(</rp><rt>re</rt><rp>)</rp>ミ<rp>(</rp><rt>mi</rt><rp>)</rp>リ<rp>(</rp><rt>ri</rt><rp>)</rp>ア<rp>(</rp><rt>a</rt><rp>)</rp>最高<rp>(</rp><rt>saikō</rt><rp>)</rp>！<rp>(</rp><rt>!</rt><rp>)</rp></ruby>");
     });
 });

--- a/test/node.spec.js
+++ b/test/node.spec.js
@@ -68,19 +68,19 @@ describe("Kuroshiro Node Funtional Test", () => {
     it("Convert - Wrong Parameter - Invalid Target Syllabary", () => {
         const ori = EXAMPLE_TEXT;
         expect(() => {
-            kuroshiro.convert(ori, { to: "xxxx" });
+            kuroshiro.convertSync(ori, { to: "xxxx" });
         }).toThrowError();
     });
     it("Convert - Wrong Parameter - Invalid Conversion Mode", () => {
         const ori = EXAMPLE_TEXT;
         expect(() => {
-            kuroshiro.convert(ori, { to: "hiragana", mode: "xxxx" });
+            kuroshiro.convertSync(ori, { to: "hiragana", mode: "xxxx" });
         }).toThrowError();
     });
     it("Convert - Wrong Parameter - Invalid Romanization System", () => {
         const ori = EXAMPLE_TEXT;
         expect(() => {
-            kuroshiro.convert(ori, { to: "hiragana", romajiSystem: "xxxx" });
+            kuroshiro.convertSync(ori, { to: "hiragana", romajiSystem: "xxxx" });
         }).toThrowError();
     });
     it("Token Patch", () => {
@@ -155,127 +155,127 @@ describe("Kuroshiro Node Funtional Test", () => {
     });
     it("Kanji to Hiragana(1)", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { to: "hiragana" });
         expect(result).toEqual("かんじとれたらてをつなごう、かさなるのはじんせいのライン and レミリアさいこう！");
     });
     it("Kanji to Hiragana(2)", () => {
         const ori = EXAMPLE_TEXT2;
-        const result = kuroshiro.convert(ori, { to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { to: "hiragana" });
         expect(result).toEqual("ブラウンかんへのあいがたりねぇな");
     });
     it("Kanji to Hiragana(3)", () => {
         const ori = EXAMPLE_TEXT3;
-        const result = kuroshiro.convert(ori, { to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { to: "hiragana" });
         expect(result).toEqual("せきがはらのたたかい");
     });
     it("Kanji to Katakana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { to: "katakana" });
+        const result = kuroshiro.convertSync(ori, { to: "katakana" });
         expect(result).toEqual("カンジトレタラテヲツナゴウ、カサナルノハジンセイノライン and レミリアサイコウ！");
     });
     it("Kanji to Katakana (Simple One Chara)", () => {
         const ori = "あ い う え お か き く け こ さ し す せ そ た ち つ て と な に ぬ ね の は ひ ふ へ ほ ま み む め も や ゆ よ ら り る れ ろ わ を ん が ぎ ぐ げ ご ざ じ ず ぜ ぞ だ ぢ づ で ど ば び ぶ べ ぼ ぱ ぴ ぷ ぺ ぽ きゃ きゅ きょ しゃ しゅ しょ ちゃ ちゅ ちょ にゃ にゅ にょ ひゃ ひゅ ひょ みゃ みゅ みょ りゃ りゅ りょ ぎゃ ぎゅ ぎょ じゃ じゅ じょ びゃ びゅ びょ ぴゃ ぴゅ ぴょ";
-        const result = kuroshiro.convert(ori, { to: "katakana" });
+        const result = kuroshiro.convertSync(ori, { to: "katakana" });
         expect(result).toEqual("ア イ ウ エ オ カ キ ク ケ コ サ シ ス セ ソ タ チ ツ テ ト ナ ニ ヌ ネ ノ ハ ヒ フ ヘ ホ マ ミ ム メ モ ヤ ユ ヨ ラ リ ル レ ロ ワ ヲ ン ガ ギ グ ゲ ゴ ザ ジ ズ ゼ ゾ ダ ヂ ヅ デ ド バ ビ ブ ベ ボ パ ピ プ ペ ポ キャ キュ キョ シャ シュ ショ チャ チュ チョ ニャ ニュ ニョ ヒャ ヒュ ヒョ ミャ ミュ ミョ リャ リュ リョ ギャ ギュ ギョ ジャ ジュ ジョ ビャ ビュ ビョ ピャ ピュ ピョ");
     });
     it("Kanji to Romaji", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { to: "romaji" });
+        const result = kuroshiro.convertSync(ori, { to: "romaji" });
         expect(result).toEqual("kanjitoretarateotsunagō,kasanarunowajinseinorain and remiriasaikō!");
     });
     it("Kanji to Romaji with sokuon", () => {
         const ori = "勝手に買っちゃったんだ";
-        const result = kuroshiro.convert(ori, { mode: "spaced", to: "romaji" });
+        const result = kuroshiro.convertSync(ori, { mode: "spaced", to: "romaji" });
         expect(result).toEqual("katte ni katchatta n da");
     });
     it("Kanji to Romaji with spaces", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { mode: "spaced", to: "romaji" });
+        const result = kuroshiro.convertSync(ori, { mode: "spaced", to: "romaji" });
         expect(result).toEqual("kanjitore tara te o tsunagō , kasanaru no wa jinsei no rain   and   remi ria saikō !");
     });
     it("Kanji to Romaji with passport-shiki romaji system", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { to: "romaji", romajiSystem: "passport" });
+        const result = kuroshiro.convertSync(ori, { to: "romaji", romajiSystem: "passport" });
         expect(result).toEqual("kanjitoretarateotsunago,kasanarunowajinseinorain and remiriasaiko!");
     });
     it("Kanji to Romaji misc with hepburn-shiki romaji system", () => {
         const ori = "東京、九州、丸の内、観桜、呼応、思う、長雨、記入、金融、学校、ビール、お母さん、委員";
-        const result = kuroshiro.convert(ori, { to: "romaji" });
+        const result = kuroshiro.convertSync(ori, { to: "romaji" });
         expect(result).toEqual("tōkyō,kyūshū,marunouchi,kan'ō,koō,omou,nagaame,kinyū,kin'yū,gakkō,bīru,okāsan,iin");
     });
     it("Kanji to Romaji misc with nippon-shiki romaji system", () => {
         const ori = "東京、九州、丸の内、観桜、呼応、思う、長雨、記入、金融、学校、ビール、お母さん、委員";
-        const result = kuroshiro.convert(ori, { to: "romaji", romajiSystem: "nippon" });
+        const result = kuroshiro.convertSync(ori, { to: "romaji", romajiSystem: "nippon" });
         expect(result).toEqual("tôkyô,kyûsyû,marunouti,kan'ô,koô,omou,nagaame,kinyû,kin'yû,gakkô,bîru,okâsan,iin");
     });
     it("Kanji to Romaji misc with passport-shiki romaji system", () => {
         const ori = "東京、九州、丸の内、観桜、呼応、思う、長雨、記入、金融、学校、ビール、お母さん、委員";
-        const result = kuroshiro.convert(ori, { to: "romaji", romajiSystem: "passport" });
+        const result = kuroshiro.convertSync(ori, { to: "romaji", romajiSystem: "passport" });
         expect(result).toEqual("tokyo,kyushu,marunouchi,kano,koo,omou,nagaame,kinyu,kinyu,gakko,biru,okasan,iin");
     });
     it("Kanji to Hiragana with spaces", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { mode: "spaced", to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { mode: "spaced", to: "hiragana" });
         expect(result).toEqual("かんじとれ たら て を つなごう 、 かさなる の は じんせい の ライン   and   レミ リア さいこう ！");
     });
     it("Kanji to Katakana with spaces", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { mode: "spaced", to: "katakana" });
+        const result = kuroshiro.convertSync(ori, { mode: "spaced", to: "katakana" });
         expect(result).toEqual("カンジトレ タラ テ ヲ ツナゴウ 、 カサナル ノ ハ ジンセイ ノ ライン   and   レミ リア サイコウ ！");
     });
     it("Kanji to Hiragana with okurigana(1)", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("感(かん)じ取(と)れたら手(て)を繋(つな)ごう、重(かさ)なるのは人生(じんせい)のライン and レミリア最高(さいこう)！");
     });
     it("Kanji to Hiragana with okurigana(2)", () => {
         const ori = EXAMPLE_TEXT2;
-        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("ブラウン管(かん)への愛(あい)が足(た)りねぇな");
     });
     it("Kanji to Hiragana with okurigana(3)", () => {
         const ori = EXAMPLE_TEXT3;
-        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("関ヶ原(せきがはら)の戦(たたか)い");
     });
     it("Kanji to Hiragana with okurigana(4)", () => {
         const ori = EXAMPLE_TEXT4;
-        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("綺麗(きれい)な花(はな)。面白(おもしろ)い映画(えいが)。面白(おもしろ)かったです。");
     });
     it("Kanji to Hiragana with okurigana(5)", () => {
         const ori = EXAMPLE_TEXT5;
-        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("言(い)い訳(わけ)");
     });
     it("Kanji to Hiragana with okurigana(6)", () => {
         const ori = EXAMPLE_TEXT6;
-        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { mode: "okurigana", to: "hiragana" });
         expect(result).toEqual("可愛(かわい)い");
     });
     it("Kanji to Katakana with okurigana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "katakana" });
+        const result = kuroshiro.convertSync(ori, { mode: "okurigana", to: "katakana" });
         expect(result).toEqual("感(カン)じ取(ト)れたら手(テ)を繋(ツナ)ごう、重(カサ)なるのは人生(ジンセイ)のライン and レミリア最高(サイコウ)！");
     });
     it("Kanji to Romaji with okurigana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { mode: "okurigana", to: "romaji" });
+        const result = kuroshiro.convertSync(ori, { mode: "okurigana", to: "romaji" });
         expect(result).toEqual("感(kan)じ取(to)れたら手(te)を繋(tsuna)ごう、重(kasa)なるのは人生(jinsei)のライン and レミリア最高(saikō)！");
     });
     it("Kanji to Hiragana with furigana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { mode: "furigana", to: "hiragana" });
+        const result = kuroshiro.convertSync(ori, { mode: "furigana", to: "hiragana" });
         expect(result).toEqual("<ruby>感<rp>(</rp><rt>かん</rt><rp>)</rp></ruby>じ<ruby>取<rp>(</rp><rt>と</rt><rp>)</rp></ruby>れたら<ruby>手<rp>(</rp><rt>て</rt><rp>)</rp></ruby>を<ruby>繋<rp>(</rp><rt>つな</rt><rp>)</rp></ruby>ごう、<ruby>重<rp>(</rp><rt>かさ</rt><rp>)</rp></ruby>なるのは<ruby>人生<rp>(</rp><rt>じんせい</rt><rp>)</rp></ruby>のライン and レミリア<ruby>最高<rp>(</rp><rt>さいこう</rt><rp>)</rp></ruby>！");
     });
     it("Kanji to Katakana with furigana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { mode: "furigana", to: "katakana" });
+        const result = kuroshiro.convertSync(ori, { mode: "furigana", to: "katakana" });
         expect(result).toEqual("<ruby>感<rp>(</rp><rt>カン</rt><rp>)</rp></ruby>じ<ruby>取<rp>(</rp><rt>ト</rt><rp>)</rp></ruby>れたら<ruby>手<rp>(</rp><rt>テ</rt><rp>)</rp></ruby>を<ruby>繋<rp>(</rp><rt>ツナ</rt><rp>)</rp></ruby>ごう、<ruby>重<rp>(</rp><rt>カサ</rt><rp>)</rp></ruby>なるのは<ruby>人生<rp>(</rp><rt>ジンセイ</rt><rp>)</rp></ruby>のライン and レミリア<ruby>最高<rp>(</rp><rt>サイコウ</rt><rp>)</rp></ruby>！");
     });
     it("Kanji to Romaji with furigana", () => {
         const ori = EXAMPLE_TEXT;
-        const result = kuroshiro.convert(ori, { mode: "furigana", to: "romaji" });
+        const result = kuroshiro.convertSync(ori, { mode: "furigana", to: "romaji" });
         expect(result).toEqual("<ruby>感<rp>(</rp><rt>kan</rt><rp>)</rp>じ<rp>(</rp><rt>ji</rt><rp>)</rp>取<rp>(</rp><rt>to</rt><rp>)</rp>れ<rp>(</rp><rt>re</rt><rp>)</rp>た<rp>(</rp><rt>ta</rt><rp>)</rp>ら<rp>(</rp><rt>ra</rt><rp>)</rp>手<rp>(</rp><rt>te</rt><rp>)</rp>を<rp>(</rp><rt>o</rt><rp>)</rp>繋<rp>(</rp><rt>tsuna</rt><rp>)</rp>ご<rp>(</rp><rt>go</rt><rp>)</rp>う<rp>(</rp><rt>u</rt><rp>)</rp>、<rp>(</rp><rt>,</rt><rp>)</rp>重<rp>(</rp><rt>kasa</rt><rp>)</rp>な<rp>(</rp><rt>na</rt><rp>)</rp>る<rp>(</rp><rt>ru</rt><rp>)</rp>の<rp>(</rp><rt>no</rt><rp>)</rp>は<rp>(</rp><rt>wa</rt><rp>)</rp>人生<rp>(</rp><rt>jinsei</rt><rp>)</rp>の<rp>(</rp><rt>no</rt><rp>)</rp>ラ<rp>(</rp><rt>ra</rt><rp>)</rp>イ<rp>(</rp><rt>i</rt><rp>)</rp>ン<rp>(</rp><rt>n</rt><rp>)</rp> <rp>(</rp><rt> </rt><rp>)</rp>a<rp>(</rp><rt>a</rt><rp>)</rp>n<rp>(</rp><rt>n</rt><rp>)</rp>d<rp>(</rp><rt>d</rt><rp>)</rp> <rp>(</rp><rt> </rt><rp>)</rp>レ<rp>(</rp><rt>re</rt><rp>)</rp>ミ<rp>(</rp><rt>mi</rt><rp>)</rp>リ<rp>(</rp><rt>ri</rt><rp>)</rp>ア<rp>(</rp><rt>a</rt><rp>)</rp>最高<rp>(</rp><rt>saikō</rt><rp>)</rp>！<rp>(</rp><rt>!</rt><rp>)</rp></ruby>");
     });
 });


### PR DESCRIPTION
In reference to #50 :

I've made a quick stab at turning kuroshiro (and kuroshiro-analyzer-kuromoji) sync, and I found that the dependency kuromoji has lag when building the data files so requires callback/promise when initialising kuroshiro/kuroshiro-analyzer-kuromoji -- since @hexenq stated that other analyzers need to be async, this is not a blocking issue to going sync IMO.

My exploration was mainly to see if it is easy enough to change the `kuroshiro.convert` to sync (it is). I would maybe advocate for creating additional functions with a `Sync` suffix to separate between async and sync return output. Other analyzers will need to support synchronous `parse` (i.e. `parseSync`) since that's used within `kuroshiro.convert` method.