### PR TITLE
Add .js extension in imports

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -18,7 +18,7 @@ import {
     kanaToHiragna,
     kanaToKatakana,
     kanaToRomaji
-} from "./util";
+} from "./util.js";
 
 /**
  * Kuroshiro Class

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-import Kuroshiro from "./core";
+import Kuroshiro from "./core.js";
 
 export default Kuroshiro;


### PR DESCRIPTION
Adding `js` extension makes sure the module is web-browser compliant and the whole project loadable as a module in a modern browser.