### PR TITLE
fix(romaji): geminate a lone sokuon instead of emitting "tsu"

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -21,6 +21,70 @@ import {
 } from "./util";
 
 /**
+ * Merge a lone sokuon (っ / ッ) into the notation that follows it.
+ *
+ * A sokuon has no reading of its own — it geminates the consonant that
+ * starts the next mora. When each notation is romanised independently
+ * (which is what the furigana renderer does), a sokuon standing alone
+ * falls through to the "no mapping" branch of toRawRomaji and comes out
+ * as the literal "tsu":
+ *
+ *   座って  ->  座[suwa] っ[tsu] て[te]     // wrong
+ *   真っ赤  ->  真[ma]   っ[tsu] 赤[ka]     // wrong
+ *   カッター ->  カ[ka]   ッ[tsu] タ[ta] ー  // wrong
+ *
+ * Merging the sokuon forward gives the romaji converter the following
+ * consonant it needs, so its existing gemination rule applies:
+ *
+ *   座って  ->  座[suwa] って[tte]
+ *   真っ赤  ->  真[ma]   っ赤[kka]
+ *
+ * Reported upstream as takuyaa/kuromoji.js#53, filed against the
+ * tokenizer. It is not a tokenizer bug: kuromoji correctly returns
+ * 座っ[スワッ] + て[テ]. The error is here, in the consumer.
+ *
+ * Only the romaji paths use this. Hiragana and katakana output is
+ * unaffected, because there a sokuon is emitted as its own literal
+ * character and is already correct.
+ *
+ * A trailing sokuon with nothing to geminate (「あっ」) is left alone —
+ * it has no well-defined romanisation and inventing one here would be a
+ * separate decision.
+ *
+ * @param {Array} notations [basic, basic_type, notation, pronunciation]
+ * @returns {Array} notations with lone sokuon merged forward
+ */
+const mergeSokuonForward = function (notations) {
+    const SOKUON = /^[っッ]$/;
+    const merged = [];
+    let carry = null;
+    for (let i = 0; i < notations.length; i++) {
+        const n = notations[i];
+        if (carry) {
+            merged.push([
+                carry[0] + n[0],
+                n[1],
+                carry[2] + n[2],
+                carry[3] + n[3]
+            ]);
+            carry = null;
+        }
+        // [3] is the pronunciation; a lone sokuon is the whole of it.
+        // The last notation has nothing to merge into, so it is kept.
+        else if (SOKUON.test(n[3]) && i + 1 < notations.length) {
+            carry = n;
+        }
+        else {
+            merged.push(n);
+        }
+    }
+    if (carry) {
+        merged.push(carry); // trailing sokuon: nothing to merge into
+    }
+    return merged;
+};
+
+/**
  * Kuroshiro Class
  */
 class Kuroshiro {
@@ -244,24 +308,28 @@ class Kuroshiro {
                         }
                     }
                     return result;
-                case "romaji":
+                case "romaji": {
+                    // A lone sokuon has no reading of its own; romanising
+                    // it in isolation yields "tsu". See mergeSokuonForward.
+                    const romajiNotations = mergeSokuonForward(notations);
                     if (options.mode === "okurigana") {
-                        for (let n2 = 0; n2 < notations.length; n2++) {
-                            if (notations[n2][1] !== 1) {
-                                result += notations[n2][0];
+                        for (let n2 = 0; n2 < romajiNotations.length; n2++) {
+                            if (romajiNotations[n2][1] !== 1) {
+                                result += romajiNotations[n2][0];
                             }
                             else {
-                                result += notations[n2][0] + options.delimiter_start + toRawRomaji(notations[n2][3], options.romajiSystem) + options.delimiter_end;
+                                result += romajiNotations[n2][0] + options.delimiter_start + toRawRomaji(romajiNotations[n2][3], options.romajiSystem) + options.delimiter_end;
                             }
                         }
                     }
                     else { // furigana
                         result += "<ruby>";
-                        for (let n3 = 0; n3 < notations.length; n3++) {
-                            result += `${notations[n3][0]}<rp>${options.delimiter_start}</rp><rt>${toRawRomaji(notations[n3][3], options.romajiSystem)}</rt><rp>${options.delimiter_end}</rp>`;
+                        for (let n3 = 0; n3 < romajiNotations.length; n3++) {
+                            result += `${romajiNotations[n3][0]}<rp>${options.delimiter_start}</rp><rt>${toRawRomaji(romajiNotations[n3][3], options.romajiSystem)}</rt><rp>${options.delimiter_end}</rp>`;
                         }
                         result += "</ruby>";
                     }
+                }
                     return result;
                 case "hiragana":
                     if (options.mode === "okurigana") {

--- a/test/sokuon.spec.js
+++ b/test/sokuon.spec.js
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ *
+ * Regression tests for lone-sokuon romanisation.
+ *
+ * Reported upstream as takuyaa/kuromoji.js#53 ("座って -> suwatsute,
+ * should be suwatte"), filed against the tokenizer. It is not a tokenizer
+ * bug — kuromoji returns 座っ[スワッ] + て[テ], which is correct. The error
+ * is here: the furigana renderer romanises each notation independently,
+ * so a sokuon standing on its own has no following consonant to geminate
+ * and falls through to the literal "tsu".
+ *
+ * `normal` mode was already correct (the whole token is romanised as a
+ * unit), which is why the issue looked unreproducible at first. `furigana`
+ * mode is the one that breaks — and it is the mode used for ruby output.
+ */
+
+import KuromojiAnalyzer from "kuroshiro-analyzer-kuromoji";
+import Kuroshiro from "../src";
+
+/** Strip the <rp> fallbacks and the wrapper so assertions read clearly. */
+const plain = str => str.replace(/<rp>.*?<\/rp>/g, "").replace(/<\/?ruby>/g, "");
+
+describe("Lone sokuon romanisation", () => {
+    let kuroshiro;
+
+    beforeAll(async () => {
+        kuroshiro = new Kuroshiro();
+        await kuroshiro.init(new KuromojiAnalyzer());
+    });
+
+    describe("furigana mode geminates instead of emitting 'tsu'", () => {
+        it("座って (verb, sokuon in okurigana)", async () => {
+            const result = await kuroshiro.convert("座って", { to: "romaji", mode: "furigana" });
+            expect(plain(result)).toBe("座<rt>suwa</rt>って<rt>tte</rt>");
+            expect(result).not.toContain("tsu");
+        });
+
+        it("行った (verb, different consonant)", async () => {
+            const result = await kuroshiro.convert("行った", { to: "romaji", mode: "furigana" });
+            expect(plain(result)).toBe("行<rt>i</rt>った<rt>tta</rt>");
+        });
+
+        it("真っ赤 (sokuon between two kanji)", async () => {
+            const result = await kuroshiro.convert("真っ赤", { to: "romaji", mode: "furigana" });
+            expect(plain(result)).toBe("真<rt>ma</rt>っ赤<rt>kka</rt>");
+        });
+
+        it("カッター (katakana sokuon)", async () => {
+            const result = await kuroshiro.convert("カッター", { to: "romaji", mode: "furigana" });
+            expect(plain(result)).toContain("ッタ<rt>tta</rt>");
+        });
+    });
+
+    describe("cases that were already correct stay correct", () => {
+        it("normal mode romanises the token as a unit", async () => {
+            expect(await kuroshiro.convert("座って", { to: "romaji", mode: "normal" })).toBe("suwatte");
+            expect(await kuroshiro.convert("真っ赤", { to: "romaji", mode: "normal" })).toBe("makka");
+        });
+
+        it("a sokuon inside a single token is untouched", async () => {
+            const result = await kuroshiro.convert("切符", { to: "romaji", mode: "furigana" });
+            expect(plain(result)).toBe("切符<rt>kippu</rt>");
+        });
+
+        it("hiragana furigana output is unchanged", async () => {
+            const result = await kuroshiro.convert("座って", { to: "hiragana", mode: "furigana" });
+            expect(plain(result)).toBe("座<rt>すわ</rt>って");
+        });
+
+        it("text with no sokuon is unchanged", async () => {
+            const result = await kuroshiro.convert("心を燃やせ", { to: "romaji", mode: "furigana" });
+            expect(plain(result)).toBe("心<rt>kokoro</rt>を<rt>o</rt>燃<rt>mo</rt>や<rt>ya</rt>せ<rt>se</rt>");
+        });
+    });
+
+    describe("known limitation", () => {
+        it("a trailing sokuon has nothing to geminate and is left alone", async () => {
+            // 「あっ」 has no following mora. There is no agreed romanisation
+            // for a stranded sokuon, so this is deliberately not changed.
+            const result = await kuroshiro.convert("あっ", { to: "romaji", mode: "furigana" });
+            expect(plain(result)).toContain("っ<rt>tsu</rt>");
+        });
+    });
+});


### PR DESCRIPTION
Reported upstream as takuyaa/kuromoji.js#53 ("座って -> suwatsute"), filed against the tokenizer. It is not a tokenizer bug — kuromoji returns 座っ[スワッ] + て[テ], which is correct. The error is here.

The furigana renderer romanises each notation independently. A lone sokuon then has no following consonant to geminate, misses in the romaji table, and falls through to the literal "tsu":

  座って   ->  座[suwa] っ[tsu] て[te]
  真っ赤   ->  真[ma]   っ[tsu] 赤[ka]
  カッター  ->  カ[ka]   ッ[tsu] タ[ta]

mergeSokuonForward attaches a lone sokuon to the notation that follows, so the existing gemination rule in toRawRomaji has the consonant it needs:

  座って   ->  座[suwa] って[tte]
  真っ赤   ->  真[ma]   っ赤[kka]

Applied only to the romaji paths. Hiragana and katakana output already emits the sokuon as its own literal character and is unaffected — pinned by test.

Note the issue as filed does not reproduce: `normal` mode romanises the whole token at once and has always produced "suwatte". It is `furigana` mode that breaks, which is the mode that matters for ruby output.

A trailing sokuon (「あっ」) has nothing to geminate and no agreed romanisation, so it is deliberately left as-is and pinned by a test, to make the limitation explicit rather than forgotten.

58 tests passing, up from 49; the four new gemination assertions fail against the unfixed renderer.